### PR TITLE
Fixed issues with arguments passthru

### DIFF
--- a/src/Console/Command/Run.php
+++ b/src/Console/Command/Run.php
@@ -81,7 +81,7 @@ class Run extends Command
         $store = $this->storeRepository->get($storeCode);
         $data = $this->dataProvider->getData($store);
 
-        $encodedData = escapeshellarg(\json_encode($data, JSON_FORCE_OBJECT));
+        $encodedData = \escapeshellarg(\json_encode($data, JSON_FORCE_OBJECT));
         $gulpCommand = $input->getArgument('gulp-command');
 
         $directory = $this->filesystem->getAbsoluteLocation();

--- a/src/Console/Command/Run.php
+++ b/src/Console/Command/Run.php
@@ -81,14 +81,14 @@ class Run extends Command
         $store = $this->storeRepository->get($storeCode);
         $data = $this->dataProvider->getData($store);
 
-        $encodedData = \json_encode($data, JSON_FORCE_OBJECT);
+        $encodedData = escapeshellarg(\json_encode($data, JSON_FORCE_OBJECT));
         $gulpCommand = $input->getArgument('gulp-command');
 
         $directory = $this->filesystem->getAbsoluteLocation();
         chdir($directory);
 
         $command = <<<CMD
-NODE_PATH=. ./node_modules/.bin/gulp --magento='{$encodedData}' {$gulpCommand};
+NODE_PATH=. ./node_modules/.bin/gulp --magento={$encodedData} {$gulpCommand};
 CMD;
 
         passthru($command);


### PR DESCRIPTION
JSON does not escape single quotes [as per its specification][json], and so any single quote (or indeed apostrophe) in the JSON configuration dump will fail this.

Fortunately, PHP provides a function for this, so we can improve the argument wrapping.

[json]: http://json.org